### PR TITLE
Master

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -174,7 +174,7 @@ const tree = {
     }
   ]
 }
-foreach(tree, (t) => t.key < 2)
+filter(tree, (t) => t.key < 2)
 /**
  * {
  *   key: 1,


### PR DESCRIPTION
chore: 修复readme文档中filter方法案例名称不一致的问题